### PR TITLE
Implement OrderBook functionality and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Ultra Low Latency Trading System Simulator
+
+This project is a C++ simulator for an ultra-low latency trading system. It provides a basic framework for an order book and order management.
+
+## Building the Project
+
+The project uses CMake for building. To build the project, follow these steps:
+
+1. Clone the repository.
+2. Create a build directory: `mkdir build`
+3. Change into the build directory: `cd build`
+4. Run CMake to generate the build files: `cmake ..`
+5. Compile the project: `make`
+
+## Running the Tests
+
+The project uses GoogleTest for unit testing. To run the tests, first build the project, then run the following command from the `build` directory:
+
+```bash
+ctest
+```

--- a/src/order.hpp
+++ b/src/order.hpp
@@ -24,5 +24,8 @@ struct Order {
   Order(Order &&) noexcept = default;
   Order &operator=(Order &&) noexcept = default;
   ~Order() = default;
+
+  Order(std::uint64_t i, const std::string& s, OrderSide os, double p, std::uint32_t q)
+      : id(i), symbol(s), side(os), price(p), quantity(q) {}
 };
 }  // namespace ullts

--- a/src/order_book.cpp
+++ b/src/order_book.cpp
@@ -1,20 +1,36 @@
 #include "order_book.hpp"
 
-#include <optional>
+#include <algorithm>
 #include <vector>
 
 namespace ullts {
-void OrderBook::add_order(const Order& /*order*/) {}
 
-bool OrderBook::cancel_order(std::uint64_t /*order_id*/) { return false; }
+void OrderBook::add_order(const Order &order) {
+  orders_[order.id] = order;
+}
 
-== == == = ;
+bool OrderBook::cancel_order(std::uint64_t order_id) {
+  return orders_.erase(order_id) > 0;
+}
 
-std::optional<ullts::Order> OrderBook::get_order(
-    std::uint64_t /*order_id*/) const {
+std::optional<Order> OrderBook::get_order(std::uint64_t order_id) const {
+  if (const auto it = orders_.find(order_id); it != orders_.cend()) {
+    return it->second;
+  }
   return std::nullopt;
 }
 
-std::vector<Order> OrderBook::get_all_orders() const { return {}; }
-z void OrderBook::clear() noexcept {}
+std::vector<Order> OrderBook::get_all_orders() const {
+  std::vector<Order> all_orders;
+  all_orders.reserve(orders_.size());
+  for (const auto &[id, order] : orders_) {
+    all_orders.push_back(order);
+  }
+  return all_orders;
+}
+
+void OrderBook::clear() noexcept {
+  orders_.clear();
+}
+
 }  // namespace ullts

--- a/src/order_book.hpp
+++ b/src/order_book.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "order.hpp"
@@ -32,6 +33,6 @@ class OrderBook {
   void clear() noexcept;
 
  private:
-  std::vector<Order> orders_{};
+  std::unordered_map<std::uint64_t, Order> orders_{};
 };
 }  // namespace ullts

--- a/tests/order_book_test.cpp
+++ b/tests/order_book_test.cpp
@@ -1,0 +1,57 @@
+#include "order_book.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace ullts;
+
+TEST(OrderBook, AddOrder) {
+  OrderBook book;
+  Order order(1, "AAPL", OrderSide::Buy, 150.25, 100);
+  book.add_order(order);
+
+  auto retrieved_order = book.get_order(1);
+  EXPECT_TRUE(retrieved_order.has_value());
+  EXPECT_EQ(retrieved_order->id, 1);
+}
+
+TEST(OrderBook, CancelOrder) {
+  OrderBook book;
+  Order order(1, "AAPL", OrderSide::Buy, 150.25, 100);
+  book.add_order(order);
+
+  EXPECT_TRUE(book.cancel_order(1));
+  EXPECT_FALSE(book.get_order(1).has_value());
+}
+
+TEST(OrderBook, CancelNonExistentOrder) {
+  OrderBook book;
+  EXPECT_FALSE(book.cancel_order(1));
+}
+
+TEST(OrderBook, GetOrder) {
+  OrderBook book;
+  Order order(1, "AAPL", OrderSide::Buy, 150.25, 100);
+  book.add_order(order);
+
+  auto retrieved_order = book.get_order(1);
+  EXPECT_TRUE(retrieved_order.has_value());
+  EXPECT_EQ(retrieved_order->symbol, "AAPL");
+}
+
+TEST(OrderBook, GetAllOrders) {
+  OrderBook book;
+  book.add_order(Order(1, "AAPL", OrderSide::Buy, 150.25, 100));
+  book.add_order(Order(2, "GOOG", OrderSide::Sell, 2700.50, 50));
+
+  auto all_orders = book.get_all_orders();
+  EXPECT_EQ(all_orders.size(), 2);
+}
+
+TEST(OrderBook, Clear) {
+  OrderBook book;
+  book.add_order(Order(1, "AAPL", OrderSide::Buy, 150.25, 100));
+  book.add_order(Order(2, "GOOG", OrderSide::Sell, 2700.50, 50));
+
+  book.clear();
+  EXPECT_EQ(book.get_all_orders().size(), 0);
+}


### PR DESCRIPTION
This commit provides a complete implementation for the `OrderBook` class, which was previously stubbed out.

Key changes:
- The underlying data structure in `OrderBook` is changed from `std::vector` to `std::unordered_map` for efficient O(1) average time complexity for order lookups, insertions, and cancellations.
- All methods of the `OrderBook` class (`add_order`, `cancel_order`, `get_order`, `get_all_orders`, `clear`) are fully implemented.
- A new test file, `tests/order_book_test.cpp`, is added with comprehensive unit tests for the `OrderBook` class using GoogleTest.
- A constructor is added to the `Order` struct to allow for easier object creation in the tests.
- A `README.md` file is added with instructions on how to build the project and run the tests.